### PR TITLE
set texture uniforms to fix rendering

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,9 +63,11 @@ function init(gl) {
 
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, particleTexture0);
+        gl.uniform1i(updateProgram.u_particles, 0);
 
         gl.activeTexture(gl.TEXTURE1);
         gl.bindTexture(gl.TEXTURE_2D, windTexture);
+        gl.uniform1i(updateProgram.u_wind, 1);
 
         gl.viewport(0, 0, particleTextureSize, particleTextureSize);
 


### PR DESCRIPTION
The uniform values for `u_wind` and `u_particles` were never set leading to undefined behavior. I think it was using the particles texture as the wind texture.